### PR TITLE
Create responsive Next.js homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# mgic-website-
+# MGIC Website
+
+This project contains a basic Next.js + Tailwind CSS setup for the MGIC homepage. The page includes:
+
+- Hero section with a video background and three call‑to‑action buttons.
+- Product Highlights section.
+- Signature Projects section.
+- "Why MGIC" section.
+- Contact form with a WhatsApp link.
+- Footer with an embedded map, social links, and EN/AR language toggle.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+
+Tailwind CSS can be customized in `tailwind.config.js`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mgic-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.1"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply antialiased;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "MGIC",
+  description: "MGIC Homepage",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,19 @@
+import Hero from "@/components/Hero";
+import Highlights from "@/components/Highlights";
+import Projects from "@/components/Projects";
+import Why from "@/components/Why";
+import ContactForm from "@/components/ContactForm";
+import Footer from "@/components/Footer";
+
+export default function Home() {
+  return (
+    <main className="min-h-screen flex flex-col">
+      <Hero />
+      <Highlights />
+      <Projects />
+      <Why />
+      <ContactForm />
+      <Footer />
+    </main>
+  );
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,36 @@
+export default function ContactForm() {
+  return (
+    <section className="py-16 bg-gray-50 px-4" id="contact">
+      <h2 className="text-3xl font-bold text-center mb-8">Contact Us</h2>
+      <form className="max-w-lg mx-auto grid gap-4">
+        <input
+          type="text"
+          placeholder="Name"
+          className="p-2 border rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          className="p-2 border rounded"
+        />
+        <textarea
+          placeholder="Message"
+          className="p-2 border rounded h-32"
+        />
+        <button type="submit" className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded">
+          Send Message
+        </button>
+      </form>
+      <p className="text-center mt-4">
+        <a
+          href="https://wa.me/1234567890"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-green-600 underline"
+        >
+          Chat with us on WhatsApp
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,30 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-800 text-white py-8 px-4">
+      <div className="max-w-6xl mx-auto grid gap-8 md:grid-cols-3">
+        <div className="h-48">
+          <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3151.8354345093985!2d144.9537363153157!3d-37.816279442021994!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x6ad642af0f11fd81%3A0xf577d8cfc1d492c4!2sMelbourne%20VIC%2C%20Australia!5e0!3m2!1sen!2sus!4v1614034592989!5m2!1sen!2sus"
+            width="100%"
+            height="100%"
+            allowFullScreen
+            loading="lazy"
+          />
+        </div>
+        <div className="flex flex-col items-center justify-center space-y-2">
+          <p className="font-semibold">Follow Us</p>
+          <div className="flex space-x-4">
+            <a href="#" aria-label="Facebook" className="hover:text-primary-400">FB</a>
+            <a href="#" aria-label="Twitter" className="hover:text-primary-400">TW</a>
+            <a href="#" aria-label="Instagram" className="hover:text-primary-400">IG</a>
+          </div>
+        </div>
+        <div className="flex items-center justify-center space-x-4">
+          <button className="px-2 py-1 bg-gray-700 rounded">EN</button>
+          <button className="px-2 py-1 bg-gray-700 rounded">AR</button>
+        </div>
+      </div>
+      <p className="text-center text-sm mt-6">&copy; {new Date().getFullYear()} MGIC. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,22 @@
+export default function Hero() {
+  return (
+    <section className="relative h-screen w-full overflow-hidden">
+      <video
+        className="absolute inset-0 w-full h-full object-cover"
+        autoPlay
+        loop
+        muted
+      >
+        <source src="/video.mp4" type="video/mp4" />
+      </video>
+      <div className="relative z-10 flex flex-col items-center justify-center h-full bg-black/50 text-white px-4 text-center">
+        <h1 className="text-4xl md:text-6xl font-bold mb-6">Welcome to MGIC</h1>
+        <div className="space-x-4">
+          <button className="px-4 py-2 bg-primary-600 hover:bg-primary-700 rounded">CTA 1</button>
+          <button className="px-4 py-2 bg-primary-600 hover:bg-primary-700 rounded">CTA 2</button>
+          <button className="px-4 py-2 bg-primary-600 hover:bg-primary-700 rounded">CTA 3</button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -1,0 +1,17 @@
+export default function Highlights() {
+  return (
+    <section className="py-16 max-w-6xl mx-auto px-4">
+      <h2 className="text-3xl font-bold text-center mb-8">Product Highlights</h2>
+      <div className="grid gap-6 md:grid-cols-3">
+        {[1, 2, 3].map((item) => (
+          <div key={item} className="p-6 bg-gray-100 rounded shadow">
+            <h3 className="font-semibold mb-2">Product {item}</h3>
+            <p className="text-sm text-gray-700">
+              Brief description of product {item} goes here.
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,15 @@
+export default function Projects() {
+  return (
+    <section className="py-16 bg-gray-50 px-4">
+      <h2 className="text-3xl font-bold text-center mb-8">Signature Projects</h2>
+      <div className="max-w-6xl mx-auto grid gap-6 md:grid-cols-3">
+        {[1, 2, 3].map((item) => (
+          <div key={item} className="p-6 bg-white rounded shadow">
+            <h3 className="font-semibold mb-2">Project {item}</h3>
+            <p className="text-sm text-gray-700">Description for project {item}.</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Why.tsx
+++ b/src/components/Why.tsx
@@ -1,0 +1,15 @@
+export default function Why() {
+  return (
+    <section className="py-16 px-4">
+      <h2 className="text-3xl font-bold text-center mb-8">Why MGIC</h2>
+      <ul className="max-w-4xl mx-auto grid gap-4 md:grid-cols-2">
+        {[1, 2, 3, 4].map((item) => (
+          <li key={item} className="p-4 bg-gray-100 rounded shadow">
+            <h3 className="font-semibold mb-2">Reason {item}</h3>
+            <p className="text-sm text-gray-700">Explanation for reason {item}.</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          600: '#047857',
+          700: '#065f46',
+          400: '#34d399',
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with Tailwind CSS
- implement hero section with video background and CTAs
- add product highlights, signature projects and why MGIC sections
- include contact form with WhatsApp link
- add footer with map, social links and language toggle

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852adcfcc70832c904f30d7c468215f